### PR TITLE
restructure tests so that future test cases are simpler to write. fix…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 # Trigger on pushes, PRs, and when the default branch is updated
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
 
 jobs:
   # Run the same job on Linux, macOS and Windows – helps catch OS specific issues
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x   # Use Deno 2.x to support lockfile version 5
+          deno-version: v2.x # Use Deno 2.x to support lockfile version 5
 
       # ---------------------------------------------------------
       # 3️⃣  Cache Deno's module directory ($HOME/.deno)

--- a/kv/kvSnippet.ts
+++ b/kv/kvSnippet.ts
@@ -1,7 +1,10 @@
 import { kv } from "./kvClient.ts";
 
 // add single snippet to KV
-export async function saveSnippet(uuid, snippet) {
+export async function saveSnippet(
+  uuid: string,
+  snippet: Record<string, unknown>,
+) {
   await kv.set(["snippets", uuid], snippet);
 }
 

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,7 +1,7 @@
-// deps.ts
 export {
   Application,
   Context,
   Router,
+  type RouterContext,
   send,
 } from "https://deno.land/x/oak@v12.5.0/mod.ts";

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -16,7 +16,7 @@ import snippetRouter from "./snippet.ts"; // <-- your existing snippet routes
 export function createProdRouter(): Router {
   const router = new Router();
 
-  // Health‑check / root endpoint – keeps the server alive and
+  // Health check / root endpoint – keeps the server alive and
   // gives a quick “everything is up” response.
   router.get("/health", (ctx) => {
     ctx.response.body = {

--- a/src/routes/snippet.ts
+++ b/src/routes/snippet.ts
@@ -1,5 +1,4 @@
-// src/routes/snippet.ts
-import { Context, Router } from "../deps.ts"; // Oak symbols re‑exported in deps.ts
+import { Context, Router, RouterContext } from "../deps.ts"; // Oak symbols re‑exported in deps.ts
 import { getSnippet, isoTimestamp, saveSnippet } from "../../kv/kvSnippet.ts"; // we need to open Deno KV for persistence and make the handle available.
 
 // Handler that just writes “hello” as plain‑text
@@ -35,7 +34,7 @@ async function addSnippet(ctx: Context) {
 
   // convert from Unix Epoch to ISO format
   const formatted = isoTimestamp(Date.now());
-  const created: json = {
+  const created: Record<string, unknown> = {
     user_id: uuid,
     title: payload.title,
     content: payload.content,
@@ -51,7 +50,7 @@ async function addSnippet(ctx: Context) {
   ctx.response.body = created;
 }
 
-async function getSingleSnippet(ctx: Context) {
+async function getSingleSnippet(ctx: RouterContext<"/snippet/:id">) {
   const id = ctx.params.id;
 
   if (!id) {
@@ -71,7 +70,7 @@ async function getSingleSnippet(ctx: Context) {
   // response back to user
   ctx.response.status = 200;
   ctx.response.type = "application/json";
-  ctx.response.body = snippet;
+  ctx.response.body = snippet as Record<string, unknown>;
 }
 
 // Build the router and expose it

--- a/src/routes/testRouter.ts
+++ b/src/routes/testRouter.ts
@@ -13,9 +13,8 @@
  *   (You can add more test‑only routes here later.)
  */
 
-import { Application, Router, Context } from "../deps.ts";
-//import { Application, Router, Context } from "@oak/oak"; 
-
+import { Application, Context, Router } from "../deps.ts";
+import snippetRouter from "./snippet.ts";
 
 /**
  * Build an Oak `Application` that uses the supplied KV.
@@ -33,27 +32,22 @@ export function createTestApp(kvInstance: Deno.Kv): Application {
   // Expose the test KV globally – the only place that does this.
   (globalThis as any).__TEST_KV__ = kvInstance;
 
-  const router = new Router();
-
-  router.get("/health", (ctx: Context) => {
+  // we have this only here, and the rest of the routes come from production side
+  const healthRouter = new Router();
+  healthRouter.get("/health", (ctx: Context) => {
     ctx.response.type = "application/json";
     ctx.response.body = {
-    status: "ok",
-    timestamp: new Date().toISOString(),
+      status: "ok",
+      timestamp: new Date().toISOString(),
     };
   });
 
-  // -----------------------------------------------------------------
-  // (Optional) you could mount the real snippet routes here if you
-  // want to test them together with the health endpoint:
-  //   import snippetRouter from "./snippet.ts";
-  //   router.use(snippetRouter.routes());
-  //   router.use(snippetRouter.allowedMethods());
-  // -----------------------------------------------------------------
-
   const app = new Application();
-  app.use(router.routes());
-  app.use(router.allowedMethods());
+  app.use(healthRouter.routes());
+  app.use(healthRouter.allowedMethods());
+
+  app.use(snippetRouter.routes());
+  app.use(snippetRouter.allowedMethods());
 
   return app;
 }

--- a/tests/health_test.ts
+++ b/tests/health_test.ts
@@ -1,16 +1,18 @@
-import { assertEquals, assertObjectMatch } from "@std/asserts";
-
-import { superoak } from "./superoak_wrapper.ts";
-
-import { initSuite, resetKv, teardownSuite } from "./setup.ts";
-
-import type { Application } from "../src/deps.ts"; // <-- bring the type in
+import {
+  type Application,
+  assertEquals,
+  assertObjectMatch,
+  initSuite,
+  resetKv,
+  superoak,
+  teardownSuite,
+} from "./setup.ts";
 
 let app: Application; // will be set in the suite’s before-all step
 
 Deno.test("Health endpoint suite", async (t) => {
   // ---------------------------------------------------------
-  // Suite‑wide setup (runs once)
+  // Suite setup (runs once)
   // ---------------------------------------------------------
   await t.step("setup suite", async () => {
     const suite = await initSuite();
@@ -40,7 +42,7 @@ Deno.test("Health endpoint suite", async (t) => {
   });
 
   // ---------------------------------------------------------
-  // Suite‑wide teardown (runs once after all tests)
+  // Suite teardown (runs once after all tests)
   // ---------------------------------------------------------
   await t.step("teardown suite", async () => {
     await teardownSuite();

--- a/tests/snippet_test.ts
+++ b/tests/snippet_test.ts
@@ -1,0 +1,35 @@
+// snippet_test.ts
+import {
+  type _Application,
+  assertEquals,
+  assertObjectMatch,
+  defineTestSuite,
+  superoak,
+} from "./setup.ts";
+
+defineTestSuite("Snippet endpoints test suite", async (t, app) => {
+  await t.step(
+    "POST /add with valid payload returns 201 and snippet",
+    async () => {
+      const payload = {
+        title: "Test Snippet",
+        content: "This is a test snippet.",
+      };
+
+      const request = await superoak(app);
+      const response = await request.post("/add").send(payload).expect(201);
+
+      const body = response.body as Record<string, unknown>;
+
+      // Basic shape check
+      assertObjectMatch(body, {
+        title: payload.title,
+        content: payload.content,
+      });
+
+      // Check that user_id and timestamp are present
+      assertEquals(typeof body.user_id, "string");
+      assertEquals(typeof body.timestamp, "string");
+    },
+  );
+});


### PR DESCRIPTION
Restructure tests:

- New function to abstract suite setup, creating test Deno KV and teardown
- Added happy path test for adding snippets
- Imports delegated to setup.ts so test suites are cleaner, and have only one import line

Also fixed type issues.